### PR TITLE
Proper way of reading module name

### DIFF
--- a/OCMapper.podspec
+++ b/OCMapper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = 'OCMapper'
-    s.version = '1.0.3'
+    s.version = '1.5'
     s.summary = 'NSDictionary to NSObject Mapper'
     s.homepage = 'https://github.com/aryaxt/OCMapper'
     s.license = {
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
       :file => 'License.txt'
     }
     s.author = {'Aryan Ghassemi' => 'https://github.com/aryaxt/OCMapper'}
-    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '1.0.3'}
+    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '1.5'}
     s.source_files = 'OCMapper/Source/*.{h,m}','OCMapper/Source/Categories/*.{h,m}','OCMapper/Source/Logging Provider/*.{h,m}','OCMapper/Source/Instance Provider/*.{h,m}','OCMapper/Source/Mapping Provider/*.{h,m}','OCMapper/Source/Mapping Provider/In Code Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/PLIST Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/XML Mapping/*.{h,m}' 
     s.framework = 'Foundation'
     s.requires_arc = true


### PR DESCRIPTION
Fixed mapping array of system classes for example array of strings
No need to throw an exception if mapping provider is missing, it's not always necessary to have one