### PR TITLE
Avoid use of "class" keyword

### DIFF
--- a/OCMapper.podspec
+++ b/OCMapper.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.platform = :ios, '5.0'
     s.name = 'OCMapper'
-    s.version = '1.6'
+    s.version = '1.7'
     s.summary = 'NSDictionary to NSObject Mapper'
     s.homepage = 'https://github.com/aryaxt/OCMapper'
     s.license = {
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
       :file => 'License.txt'
     }
     s.author = {'Aryan Ghassemi' => 'https://github.com/aryaxt/OCMapper'}
-    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '1.6'}
+    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '1.7'}
     s.source_files = 'OCMapper/Source/*.{h,m}','OCMapper/Source/Categories/*.{h,m}','OCMapper/Source/Logging Provider/*.{h,m}','OCMapper/Source/Instance Provider/*.{h,m}','OCMapper/Source/Mapping Provider/*.{h,m}','OCMapper/Source/Mapping Provider/In Code Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/PLIST Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/XML Mapping/*.{h,m}' 
     s.framework = 'Foundation'
     s.requires_arc = true

--- a/OCMapper/Source/Categories/NSDictionary+ObjectMapper.h
+++ b/OCMapper/Source/Categories/NSDictionary+ObjectMapper.h
@@ -30,7 +30,7 @@
 
 @interface NSDictionary (ObjectMapper)
 
-- (id)objectForClass:(Class)class;
+- (id)objectForClass:(Class)clazz;
 - (NSDictionary *)dictionaryFromObject:(NSObject *)object;
 - (NSDictionary *)dictionaryFromObject:(NSObject *)object wrappedInParentWithKey:(NSString *)key;
 

--- a/OCMapper/Source/Instance Provider/InstanceProvider.h
+++ b/OCMapper/Source/Instance Provider/InstanceProvider.h
@@ -29,8 +29,8 @@
 
 @protocol InstanceProvider <NSObject>
 
-- (BOOL)canHandleClass:(Class)class;
-- (id)emptyInstanceForClass:(Class)class;
+- (BOOL)canHandleClass:(Class)clazz;
+- (id)emptyInstanceForClass:(Class)clazz;
 - (id)emptyCollectionInstance;
 - (id)upsertObject:(NSObject *)object error:(NSError **)error;
 - (NSString *)propertyNameForObject:(NSObject *)object byCaseInsensitivePropertyName:(NSString *)caseInsensitivePropertyName;

--- a/OCMapper/Source/Instance Provider/ManagedObjectInstanceProvider.h
+++ b/OCMapper/Source/Instance Provider/ManagedObjectInstanceProvider.h
@@ -37,6 +37,6 @@ typedef enum {
 @interface ManagedObjectInstanceProvider : NSObject <InstanceProvider>
 
 - (id)initWithManagedObjectContext:(NSManagedObjectContext *)aManagedObjectContext;
-- (void)setUniqueKeys:(NSArray *)keys forClass:(Class)class withUpsertMode:(UpsertMode)upsertMode;
+- (void)setUniqueKeys:(NSArray *)keys forClass:(Class)clazz withUpsertMode:(UpsertMode)upsertMode;
 
 @end

--- a/OCMapper/Source/Mapping Provider/In Code Mapping/InCodeMappingProvider.h
+++ b/OCMapper/Source/Mapping Provider/In Code Mapping/InCodeMappingProvider.h
@@ -46,72 +46,72 @@
  *  @param dictionaryKey NSString key in the dictionary
  *  @param propertyKey   NSString name of the property
  *  @param objectType    Class to be instantiated and assigned to property
- *  @param class         Class to be assign mapping to
+ *  @param clazz         Class to be assign mapping to
  */
-- (void)mapFromDictionaryKey:(NSString *)dictionaryKey toPropertyKey:(NSString *)propertyKey withObjectType:(Class)objectType forClass:(Class)class;
+- (void)mapFromDictionaryKey:(NSString *)dictionaryKey toPropertyKey:(NSString *)propertyKey withObjectType:(Class)objectType forClass:(Class)clazz;
 
 /**
  *  Set key/property Mapping to be used for converting a dictionary to a model object
  *
  *  @param dictionaryKey NSString key in the dictionary
  *  @param propertyKey   NSString name of the property
- *  @param class         Class to be assign mapping to
+ *  @param clazz         Class to be assign mapping to
  *  @param transformer   Block to be used for transforming an item in dictionary into a desired result and assign to property
  */
-- (void)mapFromDictionaryKey:(NSString *)dictionaryKey toPropertyKey:(NSString *)propertyKey forClass:(Class)class withTransformer:(MappingTransformer)transformer;
+- (void)mapFromDictionaryKey:(NSString *)dictionaryKey toPropertyKey:(NSString *)propertyKey forClass:(Class)clazz withTransformer:(MappingTransformer)transformer;
 
 /**
  *  Set key/property Mapping to be used for converting a dictionary to a model object
  *
  *  @param dictionaryKey NSString key in the dictionary
  *  @param propertyKey   NSString name of the property
- *  @param class         Class to be assign mapping to
+ *  @param clazz         Class to be assign mapping to
  */
-- (void)mapFromDictionaryKey:(NSString *)dictionaryKey toPropertyKey:(NSString *)propertyKey forClass:(Class)class;
+- (void)mapFromDictionaryKey:(NSString *)dictionaryKey toPropertyKey:(NSString *)propertyKey forClass:(Class)clazz;
 
 /**
  *  Set key/property Mapping to be used for converting a model object to dictionary
  *
  *  @param dictionaryKey NSString key in the dictionary
  *  @param propertyKey   NSString name of the property
- *  @param class         Class to be assign mapping to
+ *  @param clazz         Class to be assign mapping to
  */
-- (void)mapFromPropertyKey:(NSString *)propertyKey toDictionaryKey:(NSString *)dictionaryKey forClass:(Class)class;
+- (void)mapFromPropertyKey:(NSString *)propertyKey toDictionaryKey:(NSString *)dictionaryKey forClass:(Class)clazz;
 
 /**
  *  Set key/property Mapping to be used for converting a model object to dictionary
  *
  *  @param dictionaryKey NSString key in the dictionary
  *  @param propertyKey   NSString name of the property
- *  @param class         Class to be assign mapping to
+ *  @param clazz         Class to be assign mapping to
  *  @param transformer   Block to be used for transforming an item in dictionary into a desired result and assign to property
  */
-- (void)mapFromPropertyKey:(NSString *)propertyKey toDictionaryKey:(NSString *)dictionaryKey forClass:(Class)class withTransformer:(MappingTransformer)transformer;
+- (void)mapFromPropertyKey:(NSString *)propertyKey toDictionaryKey:(NSString *)dictionaryKey forClass:(Class)clazz withTransformer:(MappingTransformer)transformer;
 
 /**
  *  Set keys to be excluded when mapping model to a dictionary
  *
- *  @param class        Class to be assign mapping to
+ *  @param clazz        Class to be assign mapping to
  *  @param keys         NSArray of NSStrings, include properties to be excluded when mapping
  */
-- (void)excludeMappingForClass:(Class)class withKeys:(NSArray *)keys;
+- (void)excludeMappingForClass:(Class)clazz withKeys:(NSArray *)keys;
 
 /**
  *  Set dateformatter to be used for converting a dictionary to a model object
  *
  *  @param dateFormatter NSDateFormatter a dateformatter
  *  @param propertyKey   NSString name of the property
- *  @param class         Class to be assign mapping to
+ *  @param clazz         Class to be assign mapping to
  */
-- (void)setDateFormatter:(NSDateFormatter *)dateFormatter forPropertyKey:(NSString *)propertyKey andClass:(Class)class;
+- (void)setDateFormatter:(NSDateFormatter *)dateFormatter forPropertyKey:(NSString *)propertyKey andClass:(Class)clazz;
 
 /**
  *  Set dateformatter to be used for converting a model object to a dictionary
  *
  *  @param dateFormatter NSDateFormatter a dateformatter
  *  @param propertyKey   NSString name of the property
- *  @param class         Class to be assign mapping to
+ *  @param clazz         Class to be assign mapping to
  */
-- (void)setDateFormatter:(NSDateFormatter *)dateFormatter forDictionaryKey:(NSString *)dictionaryKey andClass:(Class)class;
+- (void)setDateFormatter:(NSDateFormatter *)dateFormatter forDictionaryKey:(NSString *)dictionaryKey andClass:(Class)clazz;
 
 @end

--- a/OCMapper/Source/Mapping Provider/MappingProvider.h
+++ b/OCMapper/Source/Mapping Provider/MappingProvider.h
@@ -30,10 +30,10 @@
 
 @protocol MappingProvider <NSObject>
 
-- (ObjectMappingInfo *)mappingInfoForClass:(Class)class andDictionaryKey:(NSString *)key;
-- (ObjectMappingInfo *)mappingInfoForClass:(Class)class andPropertyKey:(NSString *)key;
-- (NSDateFormatter *)dateFormatterForClass:(Class)class andPropertyKey:(NSString *)key;
-- (NSDateFormatter *)dateFormatterForClass:(Class)class andDictionaryKey:(NSString *)key;
-- (NSArray *)excludedKeysForClass:(Class)class;
+- (ObjectMappingInfo *)mappingInfoForClass:(Class)clazz andDictionaryKey:(NSString *)key;
+- (ObjectMappingInfo *)mappingInfoForClass:(Class)clazz andPropertyKey:(NSString *)key;
+- (NSDateFormatter *)dateFormatterForClass:(Class)clazz andPropertyKey:(NSString *)key;
+- (NSDateFormatter *)dateFormatterForClass:(Class)clazz andDictionaryKey:(NSString *)key;
+- (NSArray *)excludedKeysForClass:(Class)clazz;
 
 @end

--- a/OCMapper/Source/ObjectMapper.h
+++ b/OCMapper/Source/ObjectMapper.h
@@ -37,7 +37,7 @@
 @property (nonatomic, assign) BOOL normalizeDictionary;
 
 + (ObjectMapper *)sharedInstance;
-- (id)objectFromSource:(id)source toInstanceOfClass:(Class)class;
+- (id)objectFromSource:(id)source toInstanceOfClass:(Class)clazz;
 - (id)dictionaryFromObject:(NSObject *)object;
 - (void)addInstanceProvider:(id <InstanceProvider>)instanceProvider;
 


### PR DESCRIPTION
Avoid use of "class" keyword as method parameters, it causes compile errors in certain situations when used with Swift #25