### PR TITLE
#31 Support underscore mapping (ex: first_name to firstName)

### DIFF
--- a/OCMapper.podspec
+++ b/OCMapper.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.platform = :ios, '5.0'
     s.name = 'OCMapper'
-    s.version = '2.0'
+    s.version = '2.1'
     s.summary = 'NSDictionary to NSObject Mapper'
     s.homepage = 'https://github.com/aryaxt/OCMapper'
     s.license = {
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
       :file => 'License.txt'
     }
     s.author = {'Aryan Ghassemi' => 'https://github.com/aryaxt/OCMapper'}
-    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '2.0'}
+    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '2.1'}
     s.source_files = 'OCMapper/Source/*.{h,m}','OCMapper/Source/Categories/*.{h,m}','OCMapper/Source/Logging Provider/*.{h,m}','OCMapper/Source/Instance Provider/*.{h,m}','OCMapper/Source/Mapping Provider/*.{h,m}','OCMapper/Source/Mapping Provider/In Code Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/PLIST Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/XML Mapping/*.{h,m}' 
     s.framework = 'Foundation'
     s.requires_arc = true

--- a/OCMapper/Models/Address.m
+++ b/OCMapper/Models/Address.m
@@ -28,8 +28,5 @@
 #import "Address.h"
 
 @implementation Address
-@synthesize city;
-@synthesize country;
-
 
 @end

--- a/OCMapper/Models/Comment.m
+++ b/OCMapper/Models/Comment.m
@@ -28,8 +28,5 @@
 #import "Comment.h"
 
 @implementation Comment
-@synthesize title;
-@synthesize body;
-@synthesize author;
 
 @end

--- a/OCMapper/Models/User.h
+++ b/OCMapper/Models/User.h
@@ -39,7 +39,8 @@
 @property (nonatomic, strong) Address *address;
 @property (nonatomic, strong) Address *work;
 @property (nonatomic, strong) EmailConfirmation *econfirmed;
-@property (nonatomic, strong) NSMutableArray *comments;
-@property (nonatomic, strong) NSMutableArray *randomKeywords;
+@property (nonatomic, strong) NSArray *emailConfirmations;
+@property (nonatomic, strong) NSArray *comments;
+@property (nonatomic, strong) NSArray *randomKeywords;
 
 @end

--- a/OCMapper/Models/User.m
+++ b/OCMapper/Models/User.m
@@ -28,12 +28,5 @@
 #import "User.h"
 
 @implementation User
-@synthesize firstName;
-@synthesize lastName;
-@synthesize age;
-@synthesize comments;
-@synthesize randomKeywords;
-@synthesize dateOfBirth;
-@synthesize accountCreationDate;
 
 @end

--- a/OCMapper/Source/Instance Provider/ManagedObjectInstanceProvider.m
+++ b/OCMapper/Source/Instance Provider/ManagedObjectInstanceProvider.m
@@ -178,6 +178,9 @@
 
 - (NSString *)propertyNameForObject:(NSManagedObject *)object byCaseInsensitivePropertyName:(NSString *)caseInsensitivePropertyName
 {
+	// Support underscore case (EX: map first_name to firstName)
+	caseInsensitivePropertyName = [caseInsensitivePropertyName stringByReplacingOccurrencesOfString:@"_" withString:@""];
+	
 	for (NSAttributeDescription *attributeDescription in object.entity.properties)
 	{
 		if ([[attributeDescription.name lowercaseString] isEqual:[caseInsensitivePropertyName lowercaseString]])

--- a/OCMapper/Source/Instance Provider/ObjectInstanceProvider.m
+++ b/OCMapper/Source/Instance Provider/ObjectInstanceProvider.m
@@ -79,10 +79,14 @@
 {
 	NSString *result = nil;
 	Class currentClass = [object class];
+	
 	NSString *key = [NSString stringWithFormat:@"%@.%@", NSStringFromClass(currentClass), caseInsensitivePropertyName];
 	
 	if (self.propertyNameDictionary[key])
 		return self.propertyNameDictionary[key];
+	
+	// Support underscore case (EX: map first_name to firstName)
+	caseInsensitivePropertyName = [caseInsensitivePropertyName stringByReplacingOccurrencesOfString:@"_" withString:@""];
 	
 	while (currentClass && currentClass != [NSObject class])
 	{

--- a/OCMapper/Source/ObjectMapper.m
+++ b/OCMapper/Source/ObjectMapper.m
@@ -414,6 +414,18 @@
 		return clazz;
 	};
 	
+	// Handle underscore conversion (ex: game_states to an array of GameState objects)
+	// Try using regex instead?
+	if ([className rangeOfString:@"_"].length) {
+		NSMutableString *newString = [NSMutableString string];
+
+		[[className componentsSeparatedByString:@"_"] enumerateObjectsUsingBlock:^(NSString *obj, NSUInteger idx, BOOL *stop) {
+			[newString appendString:obj.capitalizedString];
+		}];
+		
+		className = newString;
+	}
+	
 	NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleNameKey];
 	
 	if (className.length) {

--- a/OCMapperTests/ObjectMapperTests.m
+++ b/OCMapperTests/ObjectMapperTests.m
@@ -295,9 +295,7 @@
 	comment.body = @"COMMENT BODY";
 	
 	User *user = [[User alloc] init];
-	user.comments = [NSMutableArray array];
-	[user.comments addObject:comment];
-	[user.comments addObject:comment];
+	user.comments = @[comment, comment];
 	
 	NSDictionary *dictionary = [self.mapper dictionaryFromObject:user];
 	NSArray *comments = [dictionary objectForKey:@"comments"];
@@ -507,6 +505,23 @@
 	XCTAssertNotNil(dictionary[@"dateOfBirth"]);
 	XCTAssertNil(dictionary[@"age"]);
 	XCTAssertNil(dictionary[@"lastName"]);
+}
+
+- (void)testShouldMapUnderscoesCase {
+	NSDictionary *userDictionary = @{
+									 @"first_name" : @"aryan",
+									 @"e_confirmed" : @{@"value": @"maybe"},
+									 @"email_confirmations" : @[@{@"value": @"yes"}, @{@"value": @"no"}],
+									 @"random_keywords" : @[@"1", @"asd"]};
+	
+	User *user = [self.mapper objectFromSource:userDictionary toInstanceOfClass:[User class]];
+	XCTAssertTrue([user.firstName isEqualToString:@"aryan"]);
+	XCTAssertTrue([user.econfirmed.value isEqualToString:@"maybe"]);
+	XCTAssertTrue([user.randomKeywords containsObject:@"1"]);
+	XCTAssertTrue([user.randomKeywords containsObject:@"asd"]);
+	XCTAssertTrue(user.emailConfirmations.count == 2);
+	XCTAssertTrue([[user.emailConfirmations[0] valueForKey:@"value"] isEqualToString:@"yes"]);
+	XCTAssertTrue([[user.emailConfirmations[1] valueForKey:@"value"] isEqualToString:@"no"]);
 }
 
 - (void)testShouldConvertValuesInDictionaryFromNSStringToNSNumberIfNeeded {


### PR DESCRIPTION
Example of automatic conversion:

- ```first_name``` to ```firstName``` as ```String```
- ```email_confirmation``` to ```emailConfirmation``` as ```EmailConfirmation``` class
- ```email_confirmations``` to ```emailConfirmations``` as ```NSArray of EmailConfirmation``` class