### PR TITLE
Fix converting classes to Json that are part of "sub bundles"

### DIFF
--- a/OCMapper/Source/ObjectMapper.m
+++ b/OCMapper/Source/ObjectMapper.m
@@ -136,7 +136,8 @@
 - (id)processDictionaryFromObject:(NSObject *)object
 {
 	// For example when we are mapping an array of string, we shouldn't try to map the string objects inside the array
-	if ([NSBundle mainBundle] != [NSBundle bundleForClass:object.class] && [object class] != [NSArray class])
+
+	if (![self isClassPartOfMainBundle:object.class] && [object class] != [NSArray class])
 	{
 		return object;
 	}
@@ -171,7 +172,7 @@
 				[props setObject:propertyValue forKey:propertyName];
 			}
 			// If class is in the main bundle it's an application specific class
-			else if ([NSBundle mainBundle] == [NSBundle bundleForClass:[propertyValue class]])
+			else if ([self isClassPartOfMainBundle:[propertyValue class]])
 			{
 				if (propertyValue) [props setObject:[self dictionaryFromObject:propertyValue] forKey:propertyName];
 			}
@@ -558,6 +559,13 @@
 	}
 	
 	return className;
+}
+
+- (BOOL)isClassPartOfMainBundle:(Class)class
+{
+    NSString *const mainBundlePath = [NSBundle mainBundle].bundlePath;
+    NSString *const classBundlePath = [NSBundle bundleForClass:class].bundlePath;
+    return [classBundlePath rangeOfString:mainBundlePath].location != NSNotFound;
 }
 
 @end


### PR DESCRIPTION
Fixes #23 

Fix converting classes to Json that are part of 'sub bundles' of the main app (e.g. unit tests or cocoa pods).

This will:
- Fix using `OCMapper` in unit tests (as described in #23)
- Fix using `OCMapper` in pods which are in turn used by the main app
- Still keep preventing `OCMapper` from converting classes that are not part of the main app or its "sub bundles" (e.g. Foundation)

Feedback appreciated. Please let me know if there is a better solution :-)
