### PR TITLE
Provide camel case => underscore conversions for object => dictionary

### DIFF
--- a/OCMapper.podspec
+++ b/OCMapper.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.platform = :ios, '5.0'
     s.name = 'OCMapper'
-    s.version = '2.1'
+    s.version = '2.2'
     s.summary = 'NSDictionary to NSObject Mapper'
     s.homepage = 'https://github.com/aryaxt/OCMapper'
     s.license = {
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
       :file => 'License.txt'
     }
     s.author = {'Aryan Ghassemi' => 'https://github.com/aryaxt/OCMapper'}
-    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '2.1'}
+    s.source = {:git => 'https://github.com/aryaxt/OCMapper.git', :tag => '2.2'}
     s.source_files = 'OCMapper/Source/*.{h,m}','OCMapper/Source/Categories/*.{h,m}','OCMapper/Source/Logging Provider/*.{h,m}','OCMapper/Source/Instance Provider/*.{h,m}','OCMapper/Source/Mapping Provider/*.{h,m}','OCMapper/Source/Mapping Provider/In Code Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/PLIST Mapping/*.{h,m}','OCMapper/Source/Mapping Provider/XML Mapping/*.{h,m}' 
     s.framework = 'Foundation'
     s.requires_arc = true

--- a/OCMapper.xcodeproj/project.pbxproj
+++ b/OCMapper.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 		15B554A2171B7B3B0058E159 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0720;
 				LastTestingUpgradeCheck = 0610;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "Aryan Ghassemi";

--- a/OCMapper/Source/ObjectMapper.m
+++ b/OCMapper/Source/ObjectMapper.m
@@ -142,6 +142,7 @@
 	}
 	
 	NSMutableDictionary *props = [NSMutableDictionary dictionary];
+    NSRegularExpression *camelCaseRegEx = [NSRegularExpression regularExpressionWithPattern:@"(?<=[a-z])([A-Z])|([A-Z])(?=[a-z])" options:0 error:nil];
 	
 	Class currentClass = [object class];
 	
@@ -164,7 +165,9 @@
 			id propertyValue = [object valueForKey:(NSString *)originalPropertyName];
 			
 			ObjectMappingInfo *mapingInfo = [self.mappingProvider mappingInfoForClass:[object class] andPropertyKey:originalPropertyName];
-			NSString *propertyName = (mapingInfo) ? mapingInfo.dictionaryKey : originalPropertyName;
+            
+            NSString *underscoreString = [[camelCaseRegEx stringByReplacingMatchesInString:originalPropertyName options:0 range:NSMakeRange(0, originalPropertyName.length) withTemplate:@"_$1$2"] lowercaseString];
+            NSString *propertyName = (mapingInfo) ? mapingInfo.dictionaryKey : underscoreString;
 			
 			if (mapingInfo.transformer) {
 				propertyValue = mapingInfo.transformer(propertyValue, object);

--- a/OCMapperTests/ManagedObjectMapperTest.m
+++ b/OCMapperTests/ManagedObjectMapperTest.m
@@ -149,7 +149,7 @@
 	user.firstName = @"Aryan";
 	
 	NSDictionary *dictionary = [self.mapper dictionaryFromObject:user];
-	XCTAssertTrue([user.firstName isEqual:[dictionary objectForKey:@"firstName"]], @"Did Not populate dictionary properly");
+	XCTAssertTrue([user.firstName isEqual:[dictionary objectForKey:@"first_name"]], @"Did Not populate dictionary properly");
 	XCTAssertTrue([user.power isEqual:[dictionary objectForKey:@"power"]], @"Did Not populate dictionary properly");
 }
 

--- a/OCMapperTests/ObjectMapperSwiftTests.swift
+++ b/OCMapperTests/ObjectMapperSwiftTests.swift
@@ -40,7 +40,6 @@ class ObjectMapperSwiftTests : XCTestCase {
             "age":          28,
             "dateOfBirth":  date,
             "location":     ["name": "SF"],
-            "billing":      ["name": "SD"],
             "purchases":    [
                 ["summary": "bla 1", "price": 123.4],
                 ["summary": "bla 2", "price": 55],
@@ -57,9 +56,6 @@ class ObjectMapperSwiftTests : XCTestCase {
         XCTAssertNotNil(customer.location, "FAIL")
         XCTAssertTrue(customer.location!.name == "SF", "FAIL")
 
-        XCTAssertNotNil(customer.billing, "FAIL")
-        XCTAssertTrue(customer.billing!.name == "SD", "FAIL")
-        
         let purchases = customer.valueForKey("purchases") as! NSArray
         
          // Can't access calues directly in unit test target, swift throws exception because it doesn't know which target the models belong to, main target or unit test target. This won't be an issue outside of test environment
@@ -79,6 +75,7 @@ class ObjectMapperSwiftTests : XCTestCase {
         mappingProvider.mapFromDictionaryKey("address", toPropertyKey: "location", withObjectType: Location.self, forClass: Customer.self)
         mappingProvider.mapFromDictionaryKey("billing-address", toPropertyKey: "billing", withObjectType: Location.self, forClass: Customer.self)
         mappingProvider.mapFromDictionaryKey("orders", toPropertyKey: "purchases", withObjectType: Purchase.self, forClass: Customer.self)
+        mappingProvider.mapFromDictionaryKey("status", toPropertyKey: "status", withObjectType: ActivationStatus.self, forClass: Customer.self)
         
         let date = NSDate().dateByAddingTimeInterval(-5555)
         

--- a/OCMapperTests/ObjectMapperTests.m
+++ b/OCMapperTests/ObjectMapperTests.m
@@ -268,8 +268,8 @@
 	
 	NSDictionary *dictionary = [self.mapper dictionaryFromObject:user];
 	
-	XCTAssertTrue([[dictionary objectForKey:@"firstName"] isEqual:user.firstName], @"Did not populate dictionary correctly");
-	XCTAssertTrue([[dictionary objectForKey:@"lastName"] isEqual:user.lastName], @"Did not populate dictionary correctly");
+	XCTAssertTrue([[dictionary objectForKey:@"first_name"] isEqual:user.firstName], @"Did not populate dictionary correctly");
+	XCTAssertTrue([[dictionary objectForKey:@"last_name"] isEqual:user.lastName], @"Did not populate dictionary correctly");
 	XCTAssertTrue([[dictionary objectForKey:@"age"] isEqual:user.age], @"Did not populate dictionary correctly");
 }
 
@@ -425,7 +425,7 @@
 	user.firstName = @"Aryan";
 	
 	NSDictionary *dictionary = [self.mapper dictionaryFromObject:user];
-	XCTAssertTrue([user.firstName isEqual:[dictionary objectForKey:@"firstName"]], @"Did Not populate dictionary properly");
+	XCTAssertTrue([user.firstName isEqual:[dictionary objectForKey:@"first_name"]], @"Did Not populate dictionary properly");
 	XCTAssertTrue([user.power isEqual:[dictionary objectForKey:@"power"]], @"Did Not populate dictionary properly");
 }
 
@@ -484,7 +484,7 @@
 	user.randomKeywords = @[@"keyword1", @2].mutableCopy;
 	
 	NSDictionary *dictionary = [self.mapper dictionaryFromObject:user];
-	NSArray *array = [dictionary objectForKey:@"randomKeywords"];
+	NSArray *array = [dictionary objectForKey:@"random_keywords"];
 	
 	XCTAssertTrue(array.count == 2);
 	XCTAssertTrue([array[0] isEqualToString:@"keyword1"]);
@@ -498,11 +498,11 @@
 	user.age = @28;
 	user.dateOfBirth = [NSDate date];
 	
-	[self.mappingProvider excludeMappingForClass:User.class withKeys:@[@"age", @"lastName"]];
+	[self.mappingProvider excludeMappingForClass:User.class withKeys:@[@"age", @"last_name"]];
 	
 	NSDictionary *dictionary = [self.mapper dictionaryFromObject:user];
-	XCTAssertNotNil(dictionary[@"firstName"]);
-	XCTAssertNotNil(dictionary[@"dateOfBirth"]);
+	XCTAssertNotNil(dictionary[@"first_name"]);
+	XCTAssertNotNil(dictionary[@"date_of_birth"]);
 	XCTAssertNil(dictionary[@"age"]);
 	XCTAssertNil(dictionary[@"lastName"]);
 }


### PR DESCRIPTION
Right now dictionary from object creation performs a non-optional underscore => camel case conversion, in order to make the library consistent with itself, provide the inverse mapping.
