### PR TITLE
Corrected logic for 'shouldn't try to map the string objects inside t…

### DIFF
--- a/OCMapper/Source/ObjectMapper.m
+++ b/OCMapper/Source/ObjectMapper.m
@@ -136,10 +136,10 @@
 - (id)processDictionaryFromObject:(NSObject *)object
 {
 	// For example when we are mapping an array of string, we shouldn't try to map the string objects inside the array
-	if ([NSBundle mainBundle] != [NSBundle bundleForClass:object.class] && [object class] != [NSArray class])
-	{
-		return object;
-	}
+    if ([object class] == [NSArray class])
+    {
+        return object;
+    }
 	
 	NSMutableDictionary *props = [NSMutableDictionary dictionary];
 	


### PR DESCRIPTION
Hey,

I have corrected logic for 

> we shouldn't try to map the string objects inside the array

It was giving exception on test cases under test targets on swift, because main bundle & bundle name for class is not same on test targets & we can make this logic simpler
