### PR TITLE
Currently ignoring custom dateFormatters when creating dictionaries

### DIFF
--- a/OCMapper/Source/ObjectMapper.m
+++ b/OCMapper/Source/ObjectMapper.m
@@ -187,7 +187,7 @@
 					
 					if (dateFormatter)
 					{
-						propertyValue = [self.defaultDateFormatter stringFromDate:propertyValue];
+						propertyValue = [dateFormatter stringFromDate:propertyValue];
 					}
 					else
 					{


### PR DESCRIPTION
If a user explicitly provides a dateFormatter, I think you want to use it.

Looks like a simple typo.

Let me know if I am missing something. I needed to generate ISO8601 date strings to send to a service and I think line of code was tripping me up.

Thanks,
-Luther