### PR TITLE
Add NSString to NSDecimalNumber conversion

### DIFF
--- a/OCMapper/Source/ObjectMapper.m
+++ b/OCMapper/Source/ObjectMapper.m
@@ -325,6 +325,11 @@
 					{
 						nestedObject = [NSNumber numberWithDouble:[value doubleValue]];
 					}
+                    // Convert NSString to NSDecimalNumber if needed
+                    else if ([propertyTypeString isEqualToString:@"NSDecimalNumber"] && [value isKindOfClass:[NSString class]])
+                    {
+                        nestedObject = [NSDecimalNumber decimalNumberWithString:value];
+                    }
 					// Convert NSNumber to NSString if needed
 					else if ([propertyTypeString isEqualToString:@"NSString"] && [value isKindOfClass:[NSNumber class]])
 					{


### PR DESCRIPTION
As NSDecimalNumber is necessary for financial amount calculation, and it is something different from NSNumber, it will be convenient to add conversion from NSString directly